### PR TITLE
change submodule command to work on first install

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ customize to your requirements.
 ```sh
 git clone https://github.com/opendoor-labs/devise_paladin
 cd devise_paladin
-git submodule update --recursive apps/paladin
+git submodule update --init
 mix deps.get
 mix ecto.migrate -r Paladin.Repo
 cd apps/paladin

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ git clone https://github.com/opendoor-labs/devise_paladin
 cd devise_paladin
 git submodule update --init
 mix deps.get
+mix ecto.create -r Paladin.Repo
 mix ecto.migrate -r Paladin.Repo
 cd apps/paladin
 npm install


### PR DESCRIPTION
On first install, git requires the --init option to create the submodule.
